### PR TITLE
Better gradient flow for memory and dynamics

### DIFF
--- a/configs/muzero/avoid_fuzzy_bear.yaml
+++ b/configs/muzero/avoid_fuzzy_bear.yaml
@@ -17,12 +17,13 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   reward_values: [-0.01, 0.0, -0.5, 0.6, 1.0]
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_start: [0, 0]
       glyph_crop_size: [21, 20]
@@ -66,7 +67,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/corridor_battle.yaml
+++ b/configs/muzero/corridor_battle.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 40]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/dark_room_15x15.yaml
+++ b/configs/muzero/dark_room_15x15.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/dark_room_5x5.yaml
+++ b/configs/muzero/dark_room_5x5.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/hide_and_seek_mapped.yaml
+++ b/configs/muzero/hide_and_seek_mapped.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/mazewalk_15x15.yaml
+++ b/configs/muzero/mazewalk_15x15.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/mazewalk_9x9.yaml
+++ b/configs/muzero/mazewalk_9x9.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/mazewalk_mapped_15x15.yaml
+++ b/configs/muzero/mazewalk_mapped_15x15.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/mazewalk_mapped_9x9.yaml
+++ b/configs/muzero/mazewalk_mapped_9x9.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/memento_short.yaml
+++ b/configs/muzero/memento_short.yaml
@@ -17,12 +17,13 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   reward_values: [-0.01, 0.0, -1.0, 1.0]
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_start: [0, 0]
       glyph_crop_size: [13, 20]
@@ -66,7 +67,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/memory_test_10.yaml
+++ b/configs/muzero/memory_test_10.yaml
@@ -17,12 +17,13 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   reward_values: [-0.01, 0.0, -1.0, 1.0]
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_start: [0, 0]
       glyph_crop_size: [21, 20]
@@ -66,7 +67,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/random_room_15x15.yaml
+++ b/configs/muzero/random_room_15x15.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/random_room_5x5.yaml
+++ b/configs/muzero/random_room_5x5.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/retreat.yaml
+++ b/configs/muzero/retreat.yaml
@@ -17,12 +17,13 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   reward_values: [-0.01, 0.0, 1.0, 2.0]
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_start: [0, 0]
       glyph_crop_size: [10, 10]
@@ -66,7 +67,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/river_narrow.yaml
+++ b/configs/muzero/river_narrow.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/ultimate_room_15x15.yaml
+++ b/configs/muzero/ultimate_room_15x15.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.99
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/configs/muzero/ultimate_room_5x5.yaml
+++ b/configs/muzero/ultimate_room_5x5.yaml
@@ -17,11 +17,12 @@ train_config:
     good_total_reward_threshold: 0.5
 agent_config:
   use_priorities: false
+  update_next_trajectory_memory: true
   lr: 0.001
   max_gradient_norm: 5.0
   discount_factor: 0.95
   num_train_unroll_steps: 5
-  reanalyze_batch_size: 64
+  reanalyze_batch_size: 192
   num_train_steps: 8
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
@@ -41,7 +42,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: false
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       glyph_crop_size: [21, 30]
       num_memory_units: 8
@@ -65,7 +66,9 @@ agent_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
+      gate: 'highway'

--- a/omega/agents/nethack_muzero_agent.py
+++ b/omega/agents/nethack_muzero_agent.py
@@ -396,26 +396,46 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
             self._replay_buffer.update_priority(item.id, priorities[index])
 
     @timeit
+    @partial(jax.jit, static_argnums=0)
+    def _get_updated_memory_state_after_last_ts_batch_jit(self, trajectory_batch):
+        # Make sure terminal states are taken into account when updating memory
+        updated_memory_after_last_ts_batch = self.update_memory_batch(
+            pytree.timestamp_dim_slice(trajectory_batch['memory_before'], slice_idx=-1),
+            pytree.timestamp_dim_slice(trajectory_batch['mcts_reanalyze']['memory_state_after'], slice_idx=-1),
+            pytree.timestamp_dim_slice(trajectory_batch['actions'], slice_idx=-1),
+            pytree.timestamp_dim_slice(trajectory_batch['done'], slice_idx=-1),
+        )
+        return updated_memory_after_last_ts_batch['memory']
+
+    @timeit
+    @partial(jax.jit, static_argnums=0)
+    def _update_initial_trajectory_memory_jit(self, memories_to_update, update_source_ids, update_source):
+        def updater(memory_to_update, update_source_id):
+            update = update_source[update_source_id]
+            memory_abs_diff = jnp.mean(jnp.abs(memory_to_update[0] - update))
+            updated_memory = memory_to_update.at[0].set(update)
+            return updated_memory, memory_abs_diff
+        updated = jax.tree_map(updater, memories_to_update, update_source_ids)
+        updated_memories, memory_abs_diffs = jax.tree_transpose(
+            inner_treedef=jax.tree_structure([_ for _ in range(2)]),
+            outer_treedef=jax.tree_structure(memories_to_update),
+            pytree_to_transpose=updated
+        )
+        return updated_memories, pytree.array_mean(memory_abs_diffs)
+
+    @timeit
     def _update_next_trajectory_memory(self, replayed_items, training_batch):
         """
         Given that we have an updated memory for each trajectory in the batch,
         we can update initial memories of the trajectories that temporally follow the batch
         (provided that they still are in the replay buffer).
         """
-        @jax.jit
-        def get_updated_memory_state_after_last_ts_batch(training_batch):
-            # Make sure terminal states are taken into account when updating memory
-            updated_memory_after_last_ts_batch = self.update_memory_batch(
-                pytree.timestamp_dim_slice(training_batch['memory_before'], slice_idx=-1),
-                pytree.timestamp_dim_slice(training_batch['mcts_reanalyze']['memory_state_after'], slice_idx=-1),
-                pytree.timestamp_dim_slice(training_batch['actions'], slice_idx=-1),
-                pytree.timestamp_dim_slice(training_batch['done'], slice_idx=-1),
-            )
-            return updated_memory_after_last_ts_batch['memory']
+        updated_memory_state_after_last_ts_batch = self._get_updated_memory_state_after_last_ts_batch_jit(
+            training_batch)
 
-        updated_memory_state_after_last_ts_batch = get_updated_memory_state_after_last_ts_batch(training_batch)
-
-        memory_abs_diff_per_trajectory = []
+        items_to_update = []
+        memories_to_update = []
+        update_source_ids = []
         for batch_index, trajectory_item in enumerate(replayed_items):
             next_trajectory_id = self.TrajectoryId(
                 env_index=trajectory_item.id.env_index, step=trajectory_item.id.step + 1)
@@ -425,19 +445,22 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                 # has been evicted (this can happen with some replay buffer types, i.e. clustering replay).
                 continue
 
-            next_trajectory_memory_before = next_trajectory_item.trajectory['memory_before']['memory']
-            memory_abs_diff = jnp.mean(jnp.abs(
-                next_trajectory_memory_before[0] - updated_memory_state_after_last_ts_batch[batch_index]))
-            memory_abs_diff_per_trajectory.append(memory_abs_diff)
-            next_trajectory_item.trajectory['memory_before']['memory'] = \
-                next_trajectory_item.trajectory['memory_before']['memory'].at[0].set(
-                    updated_memory_state_after_last_ts_batch[batch_index])
+            items_to_update.append(next_trajectory_item)
+            memories_to_update.append(next_trajectory_item.trajectory['memory_before']['memory'])
+            update_source_ids.append(batch_index)
 
         stats = {}
-        if len(memory_abs_diff_per_trajectory) > 0:
+        if len(memories_to_update) > 0:
+            updated_memories, avg_memory_update_abs_diff = self._update_initial_trajectory_memory_jit(
+                memories_to_update, update_source_ids, updated_memory_state_after_last_ts_batch)
+
+            for item, updated_memory in zip(items_to_update, updated_memories):
+                item.trajectory['memory_before']['memory'] = updated_memory
+
             stats = pytree.update(stats, {
-                'avg_memory_update_abs_diff': pytree.array_mean(memory_abs_diff_per_trajectory)
+                'avg_memory_update_abs_diff': avg_memory_update_abs_diff
             })
+
         return stats
 
     def _compute_mcts_statistics(

--- a/omega/agents/nethack_muzero_agent.py
+++ b/omega/agents/nethack_muzero_agent.py
@@ -32,6 +32,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
         'lr': 1e-3,
         'use_adaptive_lr': False,
         'num_lr_warmup_steps': 0,
+        'weight_decay': 0.0,
         'discount_factor': 0.99,
         'model_config': {},
         'num_mcts_simulations': 30,
@@ -169,7 +170,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
 
         return optax.chain(
             optax.clip_by_global_norm(self._config['max_gradient_norm']),
-            optax.adamw(learning_rate=lr_schedule),
+            optax.adamw(learning_rate=lr_schedule, weight_decay=self._config['weight_decay']),
         )
 
     def _make_fake_observation(self):

--- a/omega/models/base.py
+++ b/omega/models/base.py
@@ -37,7 +37,7 @@ class ItemSelector(nn.Module):
     transformer_fc_inner_dim: int
     transformer_num_heads: int = 1
     transformer_dropout: float = 0.1
-    transformer_gate: Optional[str] = None
+    transformer_gate: str = 'skip_connection'
     deterministic: Optional[bool] = None
 
     def setup(self):
@@ -77,7 +77,7 @@ class ItemPredictor(nn.Module):
     transformer_fc_inner_dim: int
     transformer_num_heads: int = 1
     transformer_dropout: float = 0.1
-    transformer_gate: Optional[str] = None
+    transformer_gate: str = 'skip_connection'
     deterministic: Optional[bool] = None
 
     def setup(self):

--- a/omega/models/base.py
+++ b/omega/models/base.py
@@ -37,7 +37,7 @@ class ItemSelector(nn.Module):
     transformer_fc_inner_dim: int
     transformer_num_heads: int = 1
     transformer_dropout: float = 0.1
-    transformer_use_gating: bool = False
+    transformer_gate: Optional[str] = None
     deterministic: Optional[bool] = None
 
     def setup(self):
@@ -48,7 +48,7 @@ class ItemSelector(nn.Module):
             num_heads=self.transformer_num_heads,
             dropout_rate=self.transformer_dropout,
             deterministic=self.deterministic,
-            use_gating=self.transformer_use_gating,
+            gate=self.transformer_gate,
             name='selection_transformer'.format(self.name),
         )
         self._logits_producer = nn.Dense(
@@ -77,7 +77,7 @@ class ItemPredictor(nn.Module):
     transformer_fc_inner_dim: int
     transformer_num_heads: int = 1
     transformer_dropout: float = 0.1
-    transformer_use_gating: bool = False
+    transformer_gate: Optional[str] = None
     deterministic: Optional[bool] = None
 
     def setup(self):
@@ -87,7 +87,7 @@ class ItemPredictor(nn.Module):
             fc_inner_dim=self.transformer_fc_inner_dim,
             num_heads=self.transformer_num_heads,
             dropout_rate=self.transformer_dropout,
-            use_gating=self.transformer_use_gating,
+            gate=self.transformer_gate,
             deterministic=self.deterministic,
             name='selection_transformer',
         )

--- a/omega/models/nethack_muzero.py
+++ b/omega/models/nethack_muzero.py
@@ -128,12 +128,9 @@ class NethackPerceiverMuZeroModel(NethackMuZeroModelBase):
             return state
 
         # TODO: we normalize each memory cell independently, maybe we should normalize jointly
-        # max = jnp.max(state, axis=-1, keepdims=True)
-        # min = jnp.min(state, axis=-1, keepdims=True)
-        # return (state - min) / (max - min + 1e-6)
-
-        state = jnp.clip(state, -5, 5)
-        return state
+        max = jnp.max(state, axis=-1, keepdims=True)
+        min = jnp.min(state, axis=-1, keepdims=True)
+        return (state - min) / (max - min + 1e-6)
 
     def latent_state_shape(self):
         return self._state_encoder.num_memory_units, self._state_encoder.memory_dim

--- a/omega/models/nethack_muzero.py
+++ b/omega/models/nethack_muzero.py
@@ -180,11 +180,11 @@ class NethackPerceiverMuZeroModel(NethackMuZeroModelBase):
         # Fuse prev action embedding with prev memory
         prev_action_embedding = self._action_embedder(prev_action)
         prev_action_embedding = jnp.expand_dims(prev_action_embedding, axis=-2)
-        prev_memory_with_action = jnp.concatenate([prev_memory, prev_action_embedding], axis=-2)
+        latent_observation_with_action = jnp.concatenate([latent_observation, prev_action_embedding], axis=-2)
 
         # Attend from latent observation to prev memory
         representation = self._memory_aggregator(
-            latent_observation, prev_memory_with_action, deterministic=deterministic)
+            prev_memory, latent_observation_with_action, deterministic=deterministic)
         representation = self._maybe_normalize_state(representation)
 
         chex.assert_rank(representation, 3)

--- a/omega/models/nethack_muzero.py
+++ b/omega/models/nethack_muzero.py
@@ -128,9 +128,12 @@ class NethackPerceiverMuZeroModel(NethackMuZeroModelBase):
             return state
 
         # TODO: we normalize each memory cell independently, maybe we should normalize jointly
-        max = jnp.max(state, axis=-1, keepdims=True)
-        min = jnp.min(state, axis=-1, keepdims=True)
-        return (state - min) / (max - min + 1e-6)
+        # max = jnp.max(state, axis=-1, keepdims=True)
+        # min = jnp.min(state, axis=-1, keepdims=True)
+        # return (state - min) / (max - min + 1e-6)
+
+        state = jnp.clip(state, -5, 5)
+        return state
 
     def latent_state_shape(self):
         return self._state_encoder.num_memory_units, self._state_encoder.memory_dim

--- a/omega/models/nethack_state_encoder.py
+++ b/omega/models/nethack_state_encoder.py
@@ -26,7 +26,7 @@ class PerceiverNethackStateEncoder(nn.Module):
     num_perceiver_self_attention_subblocks: int = 2
     transformer_dropout: float = 0.1
     transformer_fc_inner_dim: int = 256
-    transformer_use_gating: bool = False
+    transformer_gate: Optional[str] = None
     memory_update_num_heads: int = 8
     map_attention_num_heads: int = 2
     use_fixed_positional_embeddings: bool = False
@@ -68,7 +68,7 @@ class PerceiverNethackStateEncoder(nn.Module):
                 num_blocks=self.num_perceiver_self_attention_subblocks,
                 dim=self.memory_dim,
                 fc_inner_dim=self.transformer_fc_inner_dim,
-                use_gating=self.transformer_use_gating,
+                gate=self.transformer_gate,
                 num_heads=self.memory_update_num_heads,
                 dropout_rate=self.transformer_dropout,
                 deterministic=self.deterministic,
@@ -80,7 +80,7 @@ class PerceiverNethackStateEncoder(nn.Module):
             num_blocks=1,
             dim=self.memory_dim,
             fc_inner_dim=self.transformer_fc_inner_dim,
-            use_gating=self.transformer_use_gating,
+            gate=self.transformer_gate,
             num_heads=self.memory_update_num_heads,
             dropout_rate=self.transformer_dropout,
             deterministic=self.deterministic,
@@ -91,7 +91,7 @@ class PerceiverNethackStateEncoder(nn.Module):
                 num_blocks=1,
                 dim=self.memory_dim,
                 fc_inner_dim=self.transformer_fc_inner_dim,
-                use_gating=self.transformer_use_gating,
+                gate=self.transformer_gate,
                 num_heads=self.map_attention_num_heads,
                 dropout_rate=self.transformer_dropout,
                 deterministic=self.deterministic,

--- a/omega/models/nethack_state_encoder.py
+++ b/omega/models/nethack_state_encoder.py
@@ -26,7 +26,7 @@ class PerceiverNethackStateEncoder(nn.Module):
     num_perceiver_self_attention_subblocks: int = 2
     transformer_dropout: float = 0.1
     transformer_fc_inner_dim: int = 256
-    transformer_gate: Optional[str] = None
+    transformer_gate: str = 'skip_connection'
     memory_update_num_heads: int = 8
     map_attention_num_heads: int = 2
     use_fixed_positional_embeddings: bool = False

--- a/omega/neural/gating.py
+++ b/omega/neural/gating.py
@@ -1,7 +1,34 @@
-from typing import Any, Callable, Iterable
-
 import jax
 from flax import linen as nn
+
+
+class Gate(nn.Module):
+    """
+    A convenience class for selecting the desired gate type.
+    """
+    type: str
+
+    @nn.compact
+    def __call__(self, x, y):
+        if self.type == 'skip_connection':
+            return SkipConnectionGate(name='skip')(x, y)
+        elif self.type == 'gru':
+            return GRUGate(name='gru')(x, y)
+        elif self.type == 'output':
+            return OutputGate(name='output')(x, y)
+        elif self.type == 'highway':
+            return HighwayGate(name='highway')(x, y)
+        else:
+            raise ValueError('Unknown gate type: {}'.format(self.type))
+
+
+class SkipConnectionGate(nn.Module):
+    """
+    A regular skip-connection.
+    """
+    @nn.compact
+    def __call__(self, x, y):
+        return x + y
 
 
 class OutputGate(nn.Module):
@@ -11,8 +38,23 @@ class OutputGate(nn.Module):
     """
     @nn.compact
     def __call__(self, x, y):
-        modulation = nn.Dense(features=x.shape[-1], name='modulation')(x)
-        return x + nn.sigmoid(modulation) * y
+        modulation = nn.sigmoid(nn.Dense(features=x.shape[-1], name='modulation')(x))
+        return x + modulation * y
+
+
+class HighwayGate(nn.Module):
+    """
+    Highway gating layer as proposed in "Highway Networks" paper
+    (https://arxiv.org/pdf/1505.00387.pdf)
+    """
+
+    bias_init: float = 3.0  # Initialize to pass information through the gate by default
+
+    @nn.compact
+    def __call__(self, x, y):
+        dense = nn.Dense(features=x.shape[-1], name='modulation', bias_init=nn.initializers.constant(self.bias_init))
+        modulation = nn.sigmoid(dense(x))
+        return modulation * x + (1 - modulation) * y
 
 
 class GRUGate(nn.Module):
@@ -21,18 +63,17 @@ class GRUGate(nn.Module):
     (https://arxiv.org/pdf/1910.06764.pdf), section 3.2
     """
 
-    kernel_init: Callable[[Any, Iterable[int], Any], Any] = nn.initializers.lecun_normal()
-    bias_init: Callable[[Any, Iterable[int], Any], Any] = nn.initializers.zeros
+    bias_init: float = 3.0  # Initialize to pass information through the gate by default
 
     @staticmethod
     def _mvp(m, v):
         return jax.lax.dot_general(v, m, dimension_numbers=(((v.ndim - 1,), (0,)), ((), ())))
 
     def _w_param(self, name, shape):
-        return self.param(name, self.kernel_init, shape)
+        return self.param(name, nn.initializers.lecun_normal(), shape)
 
     def _b_param(self, name, shape):
-        return self.param(name, self.bias_init, shape)
+        return self.param(name, nn.initializers.constant(self.bias_init), shape)
 
     @nn.compact
     def __call__(self, x, y):

--- a/omega/neural/gating.py
+++ b/omega/neural/gating.py
@@ -6,8 +6,8 @@ from flax import linen as nn
 
 class GRUGate(nn.Module):
     """
-    GRU gating layer as proposed in TransformerXL paper (https://arxiv.org/pdf/1910.06764.pdf),
-    section 3.2
+    GRU gating layer as proposed in "Stabilizing Transformers for Reinforcement Learning" paper
+    (https://arxiv.org/pdf/1910.06764.pdf), section 3.2
     """
 
     kernel_init: Callable[[Any, Iterable[int], Any], Any] = nn.initializers.lecun_normal()

--- a/omega/neural/gating.py
+++ b/omega/neural/gating.py
@@ -4,6 +4,17 @@ import jax
 from flax import linen as nn
 
 
+class OutputGate(nn.Module):
+    """
+    Output gating layer as proposed in "Stabilizing Transformers for Reinforcement Learning" paper
+    (https://arxiv.org/pdf/1910.06764.pdf), section 3.2
+    """
+    @nn.compact
+    def __call__(self, x, y):
+        modulation = nn.Dense(features=x.shape[-1], name='modulation')(x)
+        return x + nn.sigmoid(modulation) * y
+
+
 class GRUGate(nn.Module):
     """
     GRU gating layer as proposed in "Stabilizing Transformers for Reinforcement Learning" paper

--- a/omega/neural/transformer.py
+++ b/omega/neural/transformer.py
@@ -24,8 +24,7 @@ class TransformerBlock(nn.Module):
         self._fc_inner = nn.Dense(self.fc_inner_dim)
         self._fc = nn.Dense(self.dim)
         self._att_norm_q = nn.LayerNorm()
-        self._att_norm_k = nn.LayerNorm()
-        self._att_norm_v = nn.LayerNorm()
+        self._att_norm_kv = nn.LayerNorm()
         self._fc_norm = nn.LayerNorm()
         self._att_dropout = nn.Dropout(rate=self.dropout_rate, deterministic=self.deterministic)
         self._fc_dropout = nn.Dropout(rate=self.dropout_rate, deterministic=self.deterministic)
@@ -41,7 +40,7 @@ class TransformerBlock(nn.Module):
 
         l_prev = l
         q = self._att_norm_q(l)
-        kv = self._att_norm_k(keys_values)
+        kv = self._att_norm_kv(keys_values)
         l = self._att(q, kv)
         l = self._att_dropout(l, deterministic=deterministic)
         if self.use_gating:

--- a/tools/agent.py
+++ b/tools/agent.py
@@ -115,7 +115,7 @@ def train_agent(args):
 
             if (day + 1) % train_config['epoch_every_num_days'] == 0:
                 if args.wandb_id_file is not None:
-                    wandb.log(data=stats.to_dict(include_rolling_stats=True), step=day)
+                    wandb.log(data=stats.to_dict(include_rolling_stats=True), step=day, commit=True)
                 stats.print_summary(title='After {} days:'.format(day + 1))
                 if args.checkpoints is not None:
                     agent.save_to_checkpoint(args.checkpoints)

--- a/tools/agent.py
+++ b/tools/agent.py
@@ -80,6 +80,10 @@ def train_agent(args):
             logging.info('Memory transfer logging is enabled')
             jax.config.update('jax_transfer_guard', 'log')
 
+        if args.log_compilation:
+            logging.info('JIT compilation logging is enabled')
+            jax.config.update('jax_log_compiles', True)
+
         config = load_config(args.config)
         train_config = config['train_config']
 
@@ -157,6 +161,7 @@ def parse_args():
     train_parser.add_argument('--wandb-id-file', metavar='FILE', required=False)
     train_parser.add_argument('--log-memory-transfer', action='store_true', required=False, default=False)
     train_parser.add_argument('--log-profile', action='store_true', required=False, default=False)
+    train_parser.add_argument('--log-compilation', action='store_true', required=False, default=False)
     train_parser.add_argument('--disable-jit', action='store_true', required=False, default=False)
     train_parser.add_argument('--ray-local-mode', action='store_true', required=False, default=False)
     train_parser.set_defaults(func=train_agent)

--- a/tools/experiment_manager.py
+++ b/tools/experiment_manager.py
@@ -46,6 +46,8 @@ def run_experiment(args):
         subprocess_args.append('--log-memory-transfer')
     if args.log_profile:
         subprocess_args.append('--log-profile')
+    if args.log_compilation:
+        subprocess_args.append('--log-compilation')
     if args.disable_jit:
         subprocess_args.append('--disable-jit')
 
@@ -104,6 +106,7 @@ def parse_args():
     run_parser.add_argument('--gpu', metavar='GPU_NAME_OR_INDEX', dest='gpu', required=False, type=str, default='0')
     run_parser.add_argument('--log-memory-transfer', required=False, action='store_true', default=False)
     run_parser.add_argument('--log-profile', required=False, action='store_true', default=False)
+    run_parser.add_argument('--log-compilation', required=False, action='store_true', default=False)
     run_parser.add_argument('--disable-jit', required=False, action='store_true', default=False)
     run_parser.set_defaults(func=run_experiment)
 

--- a/tools/test_config_muzero.yaml
+++ b/tools/test_config_muzero.yaml
@@ -31,7 +31,7 @@ agent_config:
   model_config:
     num_chance_outcomes: 16
     context_dependent_state_encoder: true
-    normalize_state: true
+    normalize_state: false
     state_encoder_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 1
@@ -60,4 +60,4 @@ agent_config:
       num_blocks: 1
       num_heads: 1
       fc_inner_dim: 16
-      gate: highway
+      gate: 'highway'

--- a/tools/test_config_muzero.yaml
+++ b/tools/test_config_muzero.yaml
@@ -60,4 +60,4 @@ agent_config:
       num_blocks: 1
       num_heads: 1
       fc_inner_dim: 16
-      gate: output
+      gate: highway

--- a/tools/test_config_muzero.yaml
+++ b/tools/test_config_muzero.yaml
@@ -55,9 +55,9 @@ agent_config:
       num_blocks: 1
       num_heads: 1
       fc_inner_dim: 16
-      use_gating: true
+      gate: gru
     memory_aggregator_config:
       num_blocks: 1
       num_heads: 1
       fc_inner_dim: 16
-      use_gating: true
+      gate: output

--- a/tools/test_config_muzero.yaml
+++ b/tools/test_config_muzero.yaml
@@ -20,7 +20,8 @@ train_config:
 agent_config:
   use_priorities: false
   update_next_trajectory_memory: true
-  lr: 0.001
+  lr: 0.000075
+  use_adaptive_lr: true
   discount_factor: 0.999
   num_train_steps: 1
   num_train_unroll_steps: 2


### PR DESCRIPTION
This change is focused on improving gradient propagation through recurrent connections in memory and latent state dynamics. This is achieved by 2 changes:
* Changing cross attention in memory dynamics to make previous memory act as keys, not values (this way we have uninterrupted gradient flow through memory via skip-connections).
* Adding highway gates to memory and latent state recurrence. Without gates state variance just grows indefinitely. Highway gates worked best in my experiments.

State normalization has been disabled as it's no longer needed. It probably served a similar purpose of keeping state variance under control.

Another significant change is enabling mechanism for updating memory in replay buffer after reanalyze. In the new architecture it seems to help with learning at least in the memory_test_* environments. The performance of this mechanism has also been significantly improved by jitting its parts.

Other changes:
* Default weight decay in AdamW set to zero (it was set to its default value of 1e-4 by mistake in one of the recent changes).
* Batch size changed back to 192 (batch size of 64 doesn't perform well in memory_test_* environments).
* New logs are now send to wandb immediately, not some time after the wandb.log call.
* Added ability to specify LR per example, not per batch (not currently used).
* Added ability to specify weight decay in AdamW (not currently used).
* Added ability to add yet another layernorm at the end of the transformer block after skip connection (not currently used). I was hoping that it can help to keep state variance under control, but it affected signal propagation too much it seems.
* Added ability to log JIT calls (can be helpful to catch undesired re-compilation that hurts performance).