### PR TITLE
Fix rng usage

### DIFF
--- a/configs/muzero/avoid_fuzzy_bear.yaml
+++ b/configs/muzero/avoid_fuzzy_bear.yaml
@@ -25,6 +25,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -53,6 +54,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -68,8 +70,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/corridor_battle.yaml
+++ b/configs/muzero/corridor_battle.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/dark_room_15x15.yaml
+++ b/configs/muzero/dark_room_15x15.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/dark_room_5x5.yaml
+++ b/configs/muzero/dark_room_5x5.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/hide_and_seek_mapped.yaml
+++ b/configs/muzero/hide_and_seek_mapped.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/mazewalk_15x15.yaml
+++ b/configs/muzero/mazewalk_15x15.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/mazewalk_9x9.yaml
+++ b/configs/muzero/mazewalk_9x9.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/mazewalk_mapped_15x15.yaml
+++ b/configs/muzero/mazewalk_mapped_15x15.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/mazewalk_mapped_9x9.yaml
+++ b/configs/muzero/mazewalk_mapped_9x9.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,11 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
+      dropout_rate: 0.0

--- a/configs/muzero/memento_short.yaml
+++ b/configs/muzero/memento_short.yaml
@@ -25,6 +25,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -53,6 +54,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -68,8 +70,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/memory_test_10.yaml
+++ b/configs/muzero/memory_test_10.yaml
@@ -25,6 +25,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -53,6 +54,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -68,8 +70,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/random_room_15x15.yaml
+++ b/configs/muzero/random_room_15x15.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/random_room_5x5.yaml
+++ b/configs/muzero/random_room_5x5.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/retreat.yaml
+++ b/configs/muzero/retreat.yaml
@@ -25,6 +25,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -53,6 +54,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -68,8 +70,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/river_narrow.yaml
+++ b/configs/muzero/river_narrow.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/ultimate_room_15x15.yaml
+++ b/configs/muzero/ultimate_room_15x15.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/configs/muzero/ultimate_room_5x5.yaml
+++ b/configs/muzero/ultimate_room_5x5.yaml
@@ -24,6 +24,7 @@ agent_config:
   num_train_unroll_steps: 5
   reanalyze_batch_size: 192
   num_train_steps: 8
+  warmup_days: 50
   num_mcts_simulations: 40
   mcts_puct_c1: 1.4
   mcts_dirichlet_noise_alpha: 0.35
@@ -52,6 +53,7 @@ agent_config:
       num_perceiver_blocks: 1
       num_perceiver_self_attention_subblocks: 2
       transformer_fc_inner_dim: 128
+      transformer_dropout: 0.0
       use_bl_stats: true
       use_fixed_positional_embeddings: false
     scalar_predictor_config:
@@ -67,8 +69,10 @@ agent_config:
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0
     memory_aggregator_config:
       num_blocks: 2
       num_heads: 4
       fc_inner_dim: 128
       gate: 'highway'
+      dropout_rate: 0.0

--- a/omega/agents/nethack_muzero_agent.py
+++ b/omega/agents/nethack_muzero_agent.py
@@ -588,7 +588,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                 # Encode latent states with VQ-VAE chance outcome encoder
                 def chance_outcome_encoder(state, rng):
                     return train_state.chance_outcome_encoder_fn(params, state, deterministic, rngs={'dropout': rng})
-                batch_chance_outcome_encoder_fn = jax.vmap(chance_outcome_encoder, in_axes=(0, 0), out_axes=0)
+                batch_chance_outcome_encoder_fn = jax.vmap(chance_outcome_encoder)
                 rng, chance_outcome_key = jax.random.split(rng)
                 chance_outcome_key_batch = jax.random.split(chance_outcome_key, num_timestamps)
                 encoded_chance_outcomes = batch_chance_outcome_encoder_fn(
@@ -652,7 +652,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                         return train_state.prediction_fn(params, state, deterministic, rngs={'dropout': rng})
                     rng, prediction_key = jax.random.split(rng)
                     prediction_key_batch = jax.random.split(prediction_key, num_timestamps)
-                    batch_prediction_fn = jax.vmap(prediction_fn, in_axes=(0, 0), out_axes=0)
+                    batch_prediction_fn = jax.vmap(prediction_fn)
                     policy_log_probs, state_values = batch_prediction_fn(current_latent_states, prediction_key_batch)
 
                     # Predict the afterstate
@@ -661,7 +661,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                             params, state, action, deterministic, rngs={'dropout': rng})
                     rng, afterstate_dynamics_key = jax.random.split(rng)
                     afterstate_dynamics_key_batch = jax.random.split(afterstate_dynamics_key, num_timestamps)
-                    batch_afterstate_dynamics_fn = jax.vmap(afterstate_dynamics_fn, in_axes=(0, 0, 0), out_axes=0)
+                    batch_afterstate_dynamics_fn = jax.vmap(afterstate_dynamics_fn)
                     latent_afterstates = batch_afterstate_dynamics_fn(
                         current_latent_states, actions, afterstate_dynamics_key_batch)
 
@@ -671,7 +671,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                             params, afterstate, deterministic, rngs={'dropout': rng})
                     rng, afterstate_prediction_key = jax.random.split(rng)
                     afterstate_prediction_key_batch = jax.random.split(afterstate_prediction_key, num_timestamps)
-                    batch_afterstate_prediction_fn = jax.vmap(afterstate_prediction_fn, in_axes=(0, 0), out_axes=0)
+                    batch_afterstate_prediction_fn = jax.vmap(afterstate_prediction_fn)
                     chance_outcome_log_probs, afterstate_values = batch_afterstate_prediction_fn(
                         latent_afterstates, afterstate_prediction_key_batch)
 
@@ -681,7 +681,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                             params, latent_afterstate, chance_outcome_one_hot, deterministic, rngs={'dropout': rng})
                     rng, dynamics_key = jax.random.split(rng)
                     dynamics_key_batch = jax.random.split(dynamics_key, num_timestamps)
-                    batch_dynamics_fn = jax.vmap(dynamics_fn, in_axes=(0, 0, 0), out_axes=0)
+                    batch_dynamics_fn = jax.vmap(dynamics_fn)
                     current_latent_states, reward_log_probs = batch_dynamics_fn(
                         latent_afterstates, chance_outcome_one_hot_targets, dynamics_key_batch)
 
@@ -751,7 +751,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                     'muzero_loss': loss,
                 }
 
-            batch_loss = jax.vmap(trajectory_loss, in_axes=(None, 0, 0), out_axes=(0, 0))
+            batch_loss = jax.vmap(trajectory_loss, in_axes=(None, 0, 0))
             batch_size = pytree.get_axis_dim(training_batch, axis=0)
             loss_key = jax.random.split(rng, batch_size)
             per_trajectory_losses, per_trajectory_loss_details = batch_loss(params, training_batch, loss_key)

--- a/omega/agents/nethack_muzero_agent.py
+++ b/omega/agents/nethack_muzero_agent.py
@@ -139,19 +139,19 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
             tx=optimizer,
             apply_fn=self._model.apply,
             initial_memory_state_fn=functools.partial(
-                self._model.apply, method=self._model.initial_memory_state, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.initial_memory_state),
             chance_outcome_encoder_fn=functools.partial(
-                self._model.apply, method=self._model.chance_outcome_encoder, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.chance_outcome_encoder),
             representation_fn=functools.partial(
-                self._model.apply, method=self._model.representation, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.representation),
             dynamics_fn=functools.partial(
-                self._model.apply, method=self._model.dynamics, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.dynamics),
             afterstate_dynamics_fn=functools.partial(
-                self._model.apply, method=self._model.afterstate_dynamics, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.afterstate_dynamics),
             prediction_fn=functools.partial(
-                self._model.apply, method=self._model.prediction, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.prediction),
             afterstate_prediction_fn=functools.partial(
-                self._model.apply, method=self._model.afterstate_prediction, rngs={'dropout': self.next_random_key()}),
+                self._model.apply, method=self._model.afterstate_prediction),
         )
 
     def _make_optimizer(self):
@@ -321,7 +321,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
         }
 
     @staticmethod
-    def _represent_trajectory(params, observation_trajectory, memory_trajectory, train_state, deterministic):
+    def _represent_trajectory(params, observation_trajectory, memory_trajectory, train_state, deterministic, rng):
         """
         Recurrently unrolls the representation function forwards starting from the initial memory state
         to embed the given observation trajectory.
@@ -330,7 +330,7 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
         representation_fn = functools.partial(train_state.representation_fn, deterministic=deterministic)
 
         def representation_loop(state, input):
-            prev_memory, first_timestamp_of_the_day = state
+            rng, prev_memory, first_timestamp_of_the_day = state
 
             prev_action = input['prev_action']
             prev_done = input['prev_done']
@@ -341,16 +341,18 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
             prev_memory = prev_memory * (1 - prev_done) + initial_memory_state * prev_done
 
             # Recurrently embed the observation and compute the updated memory
-            latent_observation, updated_memory = representation_fn(params, prev_memory, prev_action, cur_observation)
+            rng, representation_key = jax.random.split(rng)
+            latent_observation, updated_memory = representation_fn(
+                params, prev_memory, prev_action, cur_observation, rngs={'dropout': representation_key})
 
-            return (updated_memory, False), (latent_observation, updated_memory)
+            return (rng, updated_memory, False), (latent_observation, updated_memory)
 
         num_timestamps = pytree.get_axis_dim(observation_trajectory, axis=0)
         # Recompute memory within the trajectory but use a fixed initial state
         initial_memory = memory_trajectory['memory'][0]
         _, (latent_state_trajectory, updated_memory_trajectory) = jax.lax.scan(
             f=representation_loop,
-            init=(initial_memory, True),
+            init=(rng, initial_memory, True),
             xs={
                 'prev_action': memory_trajectory['prev_actions'],
                 'prev_done': memory_trajectory['prev_done'],
@@ -468,29 +470,40 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
             self, observation_trajectory_batch, memory_trajectory_batch, train_state, deterministic, rng):
         batch_size, num_timestamps = jax.tree_leaves(observation_trajectory_batch)[0].shape[:2]
 
-        represent_trajectory_batch_fn = jax.vmap(self._represent_trajectory, in_axes=(None, 0, 0, None, None))
+        rng, represent_trajectory_key = jax.random.split(rng)
+        represent_trajectory_key_batch = jax.random.split(represent_trajectory_key, batch_size)
+        represent_trajectory_batch_fn = jax.vmap(self._represent_trajectory, in_axes=(None, 0, 0, None, None, 0))
         latent_state_trajectory_batch, updated_memory_trajectory_batch = represent_trajectory_batch_fn(
             train_state.params,
             observation_trajectory_batch, memory_trajectory_batch,
-            train_state, deterministic)
+            train_state, deterministic, represent_trajectory_key_batch)
 
-        def dynamics_fn(params, state, action, deterministic):
-            next_state, reward_logits = train_state.dynamics_fn(params, state, action, deterministic=deterministic)
+        def prediction_fn(state, rng):
+            return train_state.prediction_fn(
+                train_state.params, state, deterministic=deterministic, rngs={'dropout': rng})
+
+        def afterstate_prediction_fn(afterstate, rng):
+            return train_state.afterstate_prediction_fn(
+                train_state.params, afterstate, deterministic=deterministic, rngs={'dropout': rng})
+
+        def dynamics_fn(afterstate, chance_outcome, rng):
+            next_state, reward_logits = train_state.dynamics_fn(
+                train_state.params, afterstate, chance_outcome, deterministic=deterministic, rngs={'dropout': rng})
             # Convert reward back to continuous form
             return next_state, undiscretize_expected(reward_logits, self._reward_lookup)
+
+        def afterstate_dynamics_fn(prev_state, action, rng):
+            return train_state.afterstate_dynamics_fn(
+                train_state.params, prev_state, action, deterministic=deterministic, rngs={'dropout': rng})
 
         mcts_func = functools.partial(
             mcts,
             num_actions=self.action_space.n,
             num_chance_outcomes=self._model.num_chance_outcomes,
-            prediction_fn=jax.tree_util.Partial(
-                train_state.prediction_fn, train_state.params, deterministic=deterministic),
-            afterstate_prediction_fn=jax.tree_util.Partial(
-                train_state.afterstate_prediction_fn, train_state.params, deterministic=deterministic),
-            dynamics_fn=jax.tree_util.Partial(
-                dynamics_fn, train_state.params, deterministic=deterministic),
-            afterstate_dynamics_fn=jax.tree_util.Partial(
-                train_state.afterstate_dynamics_fn, train_state.params, deterministic=deterministic),
+            prediction_fn=prediction_fn,
+            afterstate_prediction_fn=afterstate_prediction_fn,
+            dynamics_fn=dynamics_fn,
+            afterstate_dynamics_fn=afterstate_dynamics_fn,
             # The meaning of discount factor is different for Stochastic MuZero MCTS because
             # every transition is split into a transition to the afterstate and a transition to the next state.
             discount_factor=math.sqrt(self._config['discount_factor']),
@@ -543,23 +556,24 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
     @timeit
     def _train(self, training_batch):
         self._train_state, train_stats, per_trajectory_loss_details = self._train_jit(
-            self._train_state, training_batch)
+            self._train_state, training_batch, self.next_random_key())
         train_stats = pytree.update(train_stats, self._replay_buffer.get_stats())
         return train_stats, per_trajectory_loss_details
 
     @timeit
     @partial(jax.jit, static_argnums=(0,))
-    def _train_jit(self, train_state, training_batch):
-        def loss_function(params):
-            def trajectory_loss(params, trajectory):
+    def _train_jit(self, train_state, training_batch, rng):
+        def loss_function(params, rng):
+            def trajectory_loss(params, trajectory, rng):
                 deterministic = self._config['train_deterministic']
 
                 num_unroll_steps = self._config['num_train_unroll_steps']
 
                 # Convert observation trajectory into a sequence of latent states for each timestamp
+                rng, representation_key = jax.random.split(rng)
                 trajectory_latent_states, _ = self._represent_trajectory(
                     params, trajectory['current_state'], trajectory['memory_before'],
-                    train_state, deterministic)
+                    train_state, deterministic, representation_key)
                 trajectory_latent_states_padded = jnp.concatenate(
                     [
                         trajectory_latent_states,
@@ -572,10 +586,13 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                 num_timestamps = trajectory_latent_states.shape[0]
 
                 # Encode latent states with VQ-VAE chance outcome encoder
-                chance_outcome_encoder_fn = functools.partial(
-                    train_state.chance_outcome_encoder_fn, deterministic=deterministic)
-                batch_chance_outcome_encoder_fn = jax.vmap(chance_outcome_encoder_fn, in_axes=(None, 0), out_axes=0)
-                encoded_chance_outcomes = batch_chance_outcome_encoder_fn(params, trajectory_latent_states)
+                def chance_outcome_encoder(state, rng):
+                    return train_state.chance_outcome_encoder_fn(params, state, deterministic, rngs={'dropout': rng})
+                batch_chance_outcome_encoder_fn = jax.vmap(chance_outcome_encoder, in_axes=(0, 0), out_axes=0)
+                rng, chance_outcome_key = jax.random.split(rng)
+                chance_outcome_key_batch = jax.random.split(chance_outcome_key, num_timestamps)
+                encoded_chance_outcomes = batch_chance_outcome_encoder_fn(
+                    trajectory_latent_states, chance_outcome_key_batch)
                 num_chance_outcomes = encoded_chance_outcomes.shape[-1]
                 chance_outcomes_one_hot = jax.nn.one_hot(
                     jnp.argmax(encoded_chance_outcomes, axis=-1), num_classes=num_chance_outcomes, dtype=jnp.float32)
@@ -631,28 +648,42 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                     )
 
                     # Predict state value and the next action
-                    prediction_fn = functools.partial(train_state.prediction_fn, deterministic=deterministic)
-                    batch_prediction_fn = jax.vmap(prediction_fn, in_axes=(None, 0), out_axes=0)
-                    policy_log_probs, state_values = batch_prediction_fn(params, current_latent_states)
+                    def prediction_fn(state, rng):
+                        return train_state.prediction_fn(params, state, deterministic, rngs={'dropout': rng})
+                    rng, prediction_key = jax.random.split(rng)
+                    prediction_key_batch = jax.random.split(prediction_key, num_timestamps)
+                    batch_prediction_fn = jax.vmap(prediction_fn, in_axes=(0, 0), out_axes=0)
+                    policy_log_probs, state_values = batch_prediction_fn(current_latent_states, prediction_key_batch)
 
                     # Predict the afterstate
-                    afterstate_dynamics_fn = functools.partial(
-                        train_state.afterstate_dynamics_fn, deterministic=deterministic)
-                    batch_afterstate_dynamics_fn = jax.vmap(afterstate_dynamics_fn, in_axes=(None, 0, 0), out_axes=0)
-                    latent_afterstates = batch_afterstate_dynamics_fn(params, current_latent_states, actions)
+                    def afterstate_dynamics_fn(state, action, rng):
+                        return train_state.afterstate_dynamics_fn(
+                            params, state, action, deterministic, rngs={'dropout': rng})
+                    rng, afterstate_dynamics_key = jax.random.split(rng)
+                    afterstate_dynamics_key_batch = jax.random.split(afterstate_dynamics_key, num_timestamps)
+                    batch_afterstate_dynamics_fn = jax.vmap(afterstate_dynamics_fn, in_axes=(0, 0, 0), out_axes=0)
+                    latent_afterstates = batch_afterstate_dynamics_fn(
+                        current_latent_states, actions, afterstate_dynamics_key_batch)
 
                     # Predict the afterstate value and the chance outcome
-                    afterstate_prediction_fn = functools.partial(
-                        train_state.afterstate_prediction_fn, deterministic=deterministic)
-                    batch_afterstate_prediction_fn = jax.vmap(afterstate_prediction_fn, in_axes=(None, 0), out_axes=0)
+                    def afterstate_prediction_fn(afterstate, rng):
+                        return train_state.afterstate_prediction_fn(
+                            params, afterstate, deterministic, rngs={'dropout': rng})
+                    rng, afterstate_prediction_key = jax.random.split(rng)
+                    afterstate_prediction_key_batch = jax.random.split(afterstate_prediction_key, num_timestamps)
+                    batch_afterstate_prediction_fn = jax.vmap(afterstate_prediction_fn, in_axes=(0, 0), out_axes=0)
                     chance_outcome_log_probs, afterstate_values = batch_afterstate_prediction_fn(
-                        params, latent_afterstates)
+                        latent_afterstates, afterstate_prediction_key_batch)
 
                     # Predict the next state and the reward
-                    dynamics_fn = functools.partial(train_state.dynamics_fn, deterministic=deterministic)
-                    batch_dynamics_fn = jax.vmap(dynamics_fn, in_axes=(None, 0, 0), out_axes=0)
+                    def dynamics_fn(latent_afterstate, chance_outcome_one_hot, rng):
+                        return train_state.dynamics_fn(
+                            params, latent_afterstate, chance_outcome_one_hot, deterministic, rngs={'dropout': rng})
+                    rng, dynamics_key = jax.random.split(rng)
+                    dynamics_key_batch = jax.random.split(dynamics_key, num_timestamps)
+                    batch_dynamics_fn = jax.vmap(dynamics_fn, in_axes=(0, 0, 0), out_axes=0)
                     current_latent_states, reward_log_probs = batch_dynamics_fn(
-                        params, latent_afterstates, chance_outcome_one_hot_targets)
+                        latent_afterstates, chance_outcome_one_hot_targets, dynamics_key_batch)
 
                     # Compute prediction losses
                     step_value_loss = rlax.l2_loss(state_values, value_targets)
@@ -720,14 +751,16 @@ class NethackMuZeroAgent(JaxTrainableAgentBase):
                     'muzero_loss': loss,
                 }
 
-            batch_loss = jax.vmap(trajectory_loss, in_axes=(None, 0), out_axes=(0, 0))
-            per_trajectory_losses, per_trajectory_loss_details = batch_loss(params, training_batch)
+            batch_loss = jax.vmap(trajectory_loss, in_axes=(None, 0, 0), out_axes=(0, 0))
+            batch_size = pytree.get_axis_dim(training_batch, axis=0)
+            loss_key = jax.random.split(rng, batch_size)
+            per_trajectory_losses, per_trajectory_loss_details = batch_loss(params, training_batch, loss_key)
             loss = jnp.mean(per_trajectory_losses)
 
             return loss, per_trajectory_loss_details
 
         grad_and_loss_details_func = jax.grad(loss_function, argnums=0, has_aux=True)
-        grads, per_trajectory_loss_details = grad_and_loss_details_func(train_state.params)
+        grads, per_trajectory_loss_details = grad_and_loss_details_func(train_state.params, rng)
         train_state = train_state.apply_gradients(grads=grads)
 
         stats = pytree.mean(per_trajectory_loss_details)

--- a/omega/neural/transformer.py
+++ b/omega/neural/transformer.py
@@ -26,7 +26,7 @@ class TransformerBlock(nn.Module):
         self._fc_norm = nn.LayerNorm()
         self._att_dropout = nn.Dropout(rate=self.dropout_rate, deterministic=self.deterministic)
         self._fc_dropout = nn.Dropout(rate=self.dropout_rate, deterministic=self.deterministic)
-        self._attention_gate = Gate(self.gate)
+        self._attention_gate = Gate('skip_connection')  #self.gate)
         self._fc_gate = Gate(self.gate)
 
     def __call__(self, queries, keys_values, deterministic=None):

--- a/omega/neural/transformer.py
+++ b/omega/neural/transformer.py
@@ -26,7 +26,7 @@ class TransformerBlock(nn.Module):
         self._fc_norm = nn.LayerNorm()
         self._att_dropout = nn.Dropout(rate=self.dropout_rate, deterministic=self.deterministic)
         self._fc_dropout = nn.Dropout(rate=self.dropout_rate, deterministic=self.deterministic)
-        self._attention_gate = Gate('skip_connection')  #self.gate)
+        self._attention_gate = Gate(self.gate)
         self._fc_gate = Gate(self.gate)
 
     def __call__(self, queries, keys_values, deterministic=None):

--- a/tools/test_config_muzero.yaml
+++ b/tools/test_config_muzero.yaml
@@ -25,6 +25,7 @@ agent_config:
   discount_factor: 0.999
   num_train_steps: 1
   num_train_unroll_steps: 2
+  warmup_days: 2
   reanalyze_batch_size: 1
   num_mcts_simulations: 2
   reward_values: [-0.01, 0.0, -1.0, 1.0]

--- a/tools/test_config_ppo.yaml
+++ b/tools/test_config_ppo.yaml
@@ -4,6 +4,7 @@ train_config:
   num_collection_steps: 4
   num_envs: 2
   num_workers: 2
+  allow_to_act_in_terminal_state_once: false
   env_name: 'MiniHack-Room-Random-5x5-v0'
   use_dense_staircase_reward: false
   observation_keys: ['glyphs', 'blstats']


### PR DESCRIPTION
The original goal of this PR was to fix PPO which has been broken after updating flax by the new RNG passing conventions. However in the process of fixing things I've discovered that RNGs in MuZero has been broken as well: all the networks used a fixed key. I've corrected that but signal propagation through memory was affected, as shown by performance in memory_test_* environments. To make things work well again I had to:
* Use non-zero dropout rate only in reward and value prediction heads.
* Add an ability to warm-up replay buffer (training on a small replay buffer with a large batch size in the beginning of training seemed to hurt things).